### PR TITLE
Some refactoring and ordering of events

### DIFF
--- a/lib/apr_web/live/order_dashboard_live.ex
+++ b/lib/apr_web/live/order_dashboard_live.ex
@@ -6,11 +6,6 @@ defmodule AprWeb.OrderDashboardLive do
   def render(assigns) do
     ~L"""
     <div class="main-live">
-      <div class="main-controllers">
-        <palette-button phx-click="today">Today</palette-button>
-        <palette-button phx-click="last_week">Last 7 Days</palette-button>
-        <palette-button phx-click="last_month">Last Month</palette-button>
-      </div>
       <section class="main-stats">
         <div class="flex flex-direction-column text-align-center">
           <div class="sans-8"> <%= Money.to_string(Money.new(@totals.amount_cents, :USD)) %> </div>
@@ -39,109 +34,25 @@ defmodule AprWeb.OrderDashboardLive do
   end
 
   def mount(_session, socket) do
-    if connected?(socket), do: AprWeb.Endpoint.subscribe("events")
+    if connected?(socket) do
+      AprWeb.Endpoint.subscribe("events")
+      send(self(), :initialize)
+    end
 
-    {:ok, get_events(socket)}
+    {:ok, assign(socket, events: [], totals: %{amount_cents: 0, commission_cents: 0})}
   end
 
-  def handle_event("today", _, socket) do
-    {:noreply, get_events(socket, 1)}
-  end
-
-  def handle_event("last_week", _, socket) do
-    {:noreply, get_events(socket, 7)}
-  end
-
-  def handle_event("last_month", _, socket) do
-    {:noreply, get_events(socket, 30)}
+  def handle_info(:initialize, socket) do
+    case Events.get_order_events do
+      {:ok, results} -> {:noreply, assign(socket, events: results.events, totals: results.totals, artworks: results.artworks) }
+      {:error, error} -> raise error
+    end
   end
 
   def handle_info(%{event: "new_event", payload: _event}, socket) do
-    {:noreply, get_events(socket)}
-  end
-
-  defp get_events(socket, day_threshold \\ 1) do
-    with events <-
-           Events.list_events(routing_key: "order.approved", day_threshold: day_threshold),
-         {:ok, artworks} <- fetch_artworks(events) do
-      assign(socket, events: events, artworks: artworks, totals: get_totals(events))
-    else
-      # we can do lot better here, i think actual solution is to have get events return {:ok,...} {:error, ..} instead of doing assign
-      [] -> assign(socket, events: [], totals: %{amount_cents: 0, commission_cents: 0})
-      {:error, error} -> IO.inspect(error)
+    case Events.get_order_events do
+      {:ok, results} -> {:noreply , assign(socket, events: results.events, totals: results.totals, artworks: results.artworks) }
+      {:error, error} -> raise error
     end
-  end
-
-  defp fetch_artworks([]), do: []
-
-  defp fetch_artworks(order_events) do
-    Neuron.Config.set(url: Application.get_env(:apr, :metaphysics)[:url])
-
-    order_id_artwork_ids =
-      order_events
-      |> Enum.reduce(%{}, fn e, acc ->
-        artwork_ids =
-          e.payload["properties"]["line_items"] |> Enum.map(fn li -> li["artwork_id"] end)
-
-        acc
-        |> Map.merge(%{e.payload["object"]["id"] => artwork_ids})
-      end)
-
-    uniq_artwork_ids = order_id_artwork_ids |> Map.values() |> List.flatten() |> Enum.uniq()
-
-    fetch_response =
-      Neuron.query(
-        """
-          query orderArtworks($ids: [String]) {
-            artworks(ids: $ids) {
-              id
-              _id
-              title
-              artist {
-                name
-              }
-              partner {
-                name
-              }
-              imageUrl
-            }
-          }
-        """,
-        %{ids: uniq_artwork_ids}
-      )
-
-    case fetch_response do
-      {:ok, response} ->
-        artworks_map =
-          response.body["data"]["artworks"]
-          |> Enum.reduce(%{}, fn a, acc -> Map.merge(acc, %{a["_id"] => a}) end)
-
-        artworks_order_map =
-          order_id_artwork_ids
-          |> Enum.reduce(%{}, fn {order_id, artwork_ids}, acc ->
-            acc
-            |> Map.merge(%{
-              order_id => Enum.map(artwork_ids, fn artwork_id -> artworks_map[artwork_id] end)
-            })
-          end)
-
-        {:ok, artworks_order_map}
-
-      error ->
-        {:error, {:could_not_fetch, error}}
-    end
-  end
-
-  defp get_totals(events) do
-    events
-    |> Enum.reduce(
-      %{amount_cents: 0, commission_cents: 0},
-      fn e, acc ->
-        %{
-          amount_cents: acc.amount_cents + e.payload["properties"]["buyer_total_cents"],
-          commission_cents: acc.commission_cents + e.payload["properties"]["commission_fee_cents"]
-        }
-      end
-    )
   end
 end

--- a/test/apr/events/events_test.exs
+++ b/test/apr/events/events_test.exs
@@ -37,28 +37,5 @@ defmodule Apr.EventsTest do
     test "create_event/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Events.create_event(@invalid_attrs)
     end
-
-    test "update_event/2 with valid data updates the event" do
-      event = event_fixture()
-      assert {:ok, %Event{} = event} = Events.update_event(event, @update_attrs)
-      assert event.payload == %{}
-    end
-
-    test "update_event/2 with invalid data returns error changeset" do
-      event = event_fixture()
-      assert {:error, %Ecto.Changeset{}} = Events.update_event(event, @invalid_attrs)
-      assert event == Events.get_event!(event.id)
-    end
-
-    test "delete_event/1 deletes the event" do
-      event = event_fixture()
-      assert {:ok, %Event{}} = Events.delete_event(event)
-      assert_raise Ecto.NoResultsError, fn -> Events.get_event!(event.id) end
-    end
-
-    test "change_event/1 returns a event changeset" do
-      event = event_fixture()
-      assert %Ecto.Changeset{} = Events.change_event(event)
-    end
   end
 end


### PR DESCRIPTION
# Changes
- Moved event related logic to `Events` context, i think it makes more sense to have this _service_ layer stuff in there and this makes our live view file more focused.

- Changed `get_events` to instead of assign to socket return `{:ok, result}` or `{:error, error}` so caller can decide what to do