### PR TITLE
update listening ports for default-websockets https

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -32,6 +32,7 @@ spec:
         image: artsy/docker-nginx:1.14.2
         ports:
           - containerPort: 80
+          - containerPort: 8443
         readinessProbe:
           tcpSocket:
             port: 80
@@ -106,7 +107,7 @@ spec:
   - port: 443
     protocol: TCP
     name: https
-    targetPort: 80
+    targetPort: 8443
   selector:
     app: aprd
     layer: application

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -32,6 +32,7 @@ spec:
         image: artsy/docker-nginx:1.14.2
         ports:
           - containerPort: 80
+          - containerPort: 8443
         readinessProbe:
           tcpSocket:
             port: 80
@@ -106,7 +107,7 @@ spec:
   - port: 443
     protocol: TCP
     name: https
-    targetPort: 80
+    targetPort: 8443
   selector:
     app: aprd
     layer: application


### PR DESCRIPTION
Converged on a `default-websockets` Nginx configuration that uses port 80 for http requests and port 8443 for https.  This works with https://github.com/artsy/currents as well cc @eessex 

```
upstream default {
  server 127.0.0.1:8080;
}
server {
  listen *:80 proxy_protocol;
  location / {
    proxy_http_version 1.1;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto 'http';
    proxy_read_timeout 60;
    proxy_send_timeout 60;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_pass http://default;
  }
}
server {
  listen *:8443 proxy_protocol;
  location / {
    proxy_http_version 1.1;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto 'https';
    proxy_read_timeout 60;
    proxy_send_timeout 60;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_pass http://default;
  }
}
```