### PR TITLE
Filter events by date

### DIFF
--- a/assets/src/app.css
+++ b/assets/src/app.css
@@ -54,19 +54,23 @@ html, body {
   font-size: 18px;
 }
 
+section.stats-details{
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  width: 90%;
+}
+
 section.event {
   margin: 30px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  align-items: flex-start;
-  width: 90%;
   flex-wrap: wrap;
 }
 
 section.artworks {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
 }
 
 .artwork-event {

--- a/lib/apr_web/live/order_dashboard_live.ex
+++ b/lib/apr_web/live/order_dashboard_live.ex
@@ -19,36 +19,21 @@ defmodule AprWeb.OrderDashboardLive do
         <palette-jumbo label="Pending Approval Commission">
           <%= currency(@active_orders.totals.commission_cents) %>
         </palette-jumbo>
-
-        <palette-jumbo label="Approved Yesterday GMV">
+      </section>
+      <section class="main-stats">
+        <palette-jumbo label="Yesterday's GMV">
           <%= currency(@approved_yesterday.totals.commission_cents) %>
         </palette-jumbo>
 
-        <palette-jumbo label="Approved Today GMV">
+        <palette-jumbo label="Today's GMV">
           <%= currency(@approved_today.totals.commission_cents) %>
         </palette-jumbo>
       </section>
-      <section class="event">
-        <h2 class="sans-6"> Approved (<%= @approved_orders.count %>) </h2>
-        <section class="artworks">
-        <%= for event <- @approved_orders.events do %>
-          <div class="artwork-event">
-            <% artwork = List.first(@artworks[event.payload["object"]["id"]]) %>
-            <img class="mb-1" src="<%= artwork["imageUrl"] %>" />
-            <div class="mb-0_5 sans-2-medium"> <%= currency(event.payload["properties"]["items_total_cents"]) %> </div>
-            <div class="serif-2-semibold color-black60"> <%= artwork["artist_names"] %> </div>
-            <div class="serif-2-italic color-black60"> <%= artwork["title"] %> </div>
-            <div class="serif-2 color-black60"> <%= artwork["partner"]["name"] %> </div>
-            <div class="serif-2 color-black30"> <a href="<%= exchange_link(event.payload["object"]["id"]) %>"> <%= event.payload["properties"]["code"] %></a></div>
-          </div>
-        <% end %>
-        </section>
-      </section>
-      <%= if !Enum.empty?(@active_orders.events) do %>
+      <section class="stats-details">
         <section class="event">
-          <h2 class="sans-6"> Current Active Orders (<%= @active_orders.count %>)</h2>
+          <h2 class="sans-6"> Approved (<%= @approved_orders.count %>) </h2>
           <section class="artworks">
-          <%= for event <- @active_orders.events do %>
+          <%= for event <- @approved_orders.events do %>
             <div class="artwork-event">
               <% artwork = List.first(@artworks[event.payload["object"]["id"]]) %>
               <img class="mb-1" src="<%= artwork["imageUrl"] %>" />
@@ -61,7 +46,25 @@ defmodule AprWeb.OrderDashboardLive do
           <% end %>
           </section>
         </section>
-      <% end %>
+        <%= if !Enum.empty?(@active_orders.events) do %>
+          <section class="event">
+            <h2 class="sans-6"> Current Active Orders (<%= @active_orders.count %>)</h2>
+            <section class="artworks">
+            <%= for event <- @active_orders.events do %>
+              <div class="artwork-event">
+                <% artwork = List.first(@artworks[event.payload["object"]["id"]]) %>
+                <img class="mb-1" src="<%= artwork["imageUrl"] %>" />
+                <div class="mb-0_5 sans-2-medium"> <%= currency(event.payload["properties"]["items_total_cents"]) %> </div>
+                <div class="serif-2-semibold color-black60"> <%= artwork["artist_names"] %> </div>
+                <div class="serif-2-italic color-black60"> <%= artwork["title"] %> </div>
+                <div class="serif-2 color-black60"> <%= artwork["partner"]["name"] %> </div>
+                <div class="serif-2 color-black30"> <a href="<%= exchange_link(event.payload["object"]["id"]) %>"> <%= event.payload["properties"]["code"] %></a></div>
+              </div>
+            <% end %>
+            </section>
+          </section>
+        <% end %>
+      </section>
     </div>
     """
   end

--- a/lib/apr_web/live/order_dashboard_live.ex
+++ b/lib/apr_web/live/order_dashboard_live.ex
@@ -19,22 +19,14 @@ defmodule AprWeb.OrderDashboardLive do
         <palette-jumbo label="Pending Approval Commission">
           <%= currency(@active_orders.totals.commission_cents) %>
         </palette-jumbo>
-
-        <palette-jumbo label="Approved Yesterday GMV">
-          <%= currency(@approved_yesterday.totals.amount_cents) %>
-        </palette-jumbo>
-
-        <palette-jumbo label="Approved Today GMV">
-          <%= currency(@approved_today.totals.amount_cents) %>
-        </palette-jumbo>
       </section>
       <section class="main-stats">
         <palette-jumbo label="Yesterday's GMV">
-          <%= currency(@approved_yesterday.totals.commission_cents) %>
+          <%= currency(@approved_yesterday.totals.amount_cents) %>
         </palette-jumbo>
 
         <palette-jumbo label="Today's GMV">
-          <%= currency(@approved_today.totals.commission_cents) %>
+          <%= currency(@approved_today.totals.amount_cents) %>
         </palette-jumbo>
       </section>
       <section class="stats-details">

--- a/lib/apr_web/live/order_dashboard_live.ex
+++ b/lib/apr_web/live/order_dashboard_live.ex
@@ -19,6 +19,14 @@ defmodule AprWeb.OrderDashboardLive do
         <palette-jumbo label="Pending Approval Commission">
           <%= currency(@active_orders.totals.commission_cents) %>
         </palette-jumbo>
+
+        <palette-jumbo label="Approved Yesterday GMV">
+          <%= currency(@approved_yesterday.totals.commission_cents) %>
+        </palette-jumbo>
+
+        <palette-jumbo label="Approved Today GMV">
+          <%= currency(@approved_today.totals.commission_cents) %>
+        </palette-jumbo>
       </section>
       <section class="event">
         <h2 class="sans-6"> Approved (<%= @approved_orders.count %>) </h2>
@@ -68,6 +76,8 @@ defmodule AprWeb.OrderDashboardLive do
      assign(socket,
        approved_orders: %{events: [], totals: %{amount_cents: 0, commission_cents: 0}, count: 0},
        active_orders: %{events: [], totals: %{amount_cents: 0, commission_cents: 0}, count: 0},
+       approved_yesterday: %{events: [], totals: %{amount_cents: 0, commission_cents: 0}, count: 0},
+       approved_today: %{events: [], totals: %{amount_cents: 0, commission_cents: 0}, count: 0},
        artworks: %{}
      )}
   end
@@ -78,14 +88,17 @@ defmodule AprWeb.OrderDashboardLive do
 
   defp repopulate(socket) do
     approved_order_events = Events.list_events(routing_key: "order.approved", day_threshold: 1)
+    approved_yesterday = Apr.Events.list_events(routing_key: "order.approved", start_date: Date.add(Date.utc_today, -1), end_date: Date.utc_today)
+    approved_today = Apr.Events.list_events(routing_key: "order.approved", start_date: Date.utc_today)
     active_orders = Events.active_orders()
-
     with {:ok, artworks} <-
            Events.fetch_artworks(approved_order_events ++ active_orders) do
       {:noreply,
        assign(socket,
          approved_orders: aggregated_data(approved_order_events),
          active_orders: aggregated_data(active_orders),
+         approved_today: aggregated_data(approved_today),
+         approved_yesterday: aggregated_data(approved_yesterday),
          artworks: artworks
        )}
     else


### PR DESCRIPTION
# Change 
We want to be able to compare today's current GMV with past days and weeks.

# Solution
Add option for querying events based on `start_date` , `end_date` and use it to show today's and yesterday's GMV in our live view dashboard.

# Selfie
![localhost_4000_](https://user-images.githubusercontent.com/1230819/58804084-fb7cba00-85de-11e9-819b-6e92b68b2111.png)
