### PR TITLE
#migration update Kubernetes config to use named ports

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -27,15 +27,18 @@ spec:
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/aprd:production
         imagePullPolicy: Always
         ports:
-        - containerPort: 8080
+        - name: aprd-http
+          containerPort: 8080
       - name: aprd-nginx
         image: artsy/docker-nginx:1.14.2
         ports:
-          - containerPort: 80
-          - containerPort: 8443
+          - name: nginx-http
+            containerPort: 80
+          - name: nginx-https
+            containerPort: 8443
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: nginx-http
           initialDelaySeconds: 5
           periodSeconds: 15
           timeoutSeconds: 10
@@ -103,11 +106,11 @@ spec:
   - port: 80
     protocol: TCP
     name: http
-    targetPort: 80
+    targetPort: nginx-http
   - port: 443
     protocol: TCP
     name: https
-    targetPort: 8443
+    targetPort: nginx-https
   selector:
     app: aprd
     layer: application

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -27,15 +27,18 @@ spec:
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/aprd:staging
         imagePullPolicy: Always
         ports:
-        - containerPort: 8080
+        - name: aprd-http
+          containerPort: 8080
       - name: aprd-nginx
         image: artsy/docker-nginx:1.14.2
         ports:
-          - containerPort: 80
-          - containerPort: 8443
+          - name: nginx-http
+            containerPort: 80
+          - name: nginx-https
+            containerPort: 8443
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: nginx-http
           initialDelaySeconds: 5
           periodSeconds: 15
           timeoutSeconds: 10
@@ -103,11 +106,11 @@ spec:
   - port: 80
     protocol: TCP
     name: http
-    targetPort: 80
+    targetPort: nginx-http
   - port: 443
     protocol: TCP
     name: https
-    targetPort: 8443
+    targetPort: nginx-https
   selector:
     app: aprd
     layer: application


### PR DESCRIPTION
Using named ports allows us to make port changes to services gracefully.  The default websockets configuration should listen on 443 rather than 8443 ( @ashkan18 I don't remember why we set it up with 8443 initially ).

Using named ports allows service selectors to reference those ports by name, and orchestrate smooth rollouts if the port numbers change.  From https://kubernetes.io/docs/concepts/services-networking/service/ ...

> Port definitions in Pods have names, and you can reference these names in the targetPort attribute of a Service. This will work even if there are a mixture of Pods in the Service, with the same network protocol available via different port numbers but a single configured name. This offers a lot of flexibility for deploying and evolving your Services. For example, you can change the port number that pods expose in the next version of your backend software, without breaking clients.

## Migration

```
hokusai staging update
hokusai production update
```