### PR TITLE
#FF Add Search Orders by Partner and User name

### DIFF
--- a/assets/src/app.css
+++ b/assets/src/app.css
@@ -93,6 +93,10 @@ input[type=text] {
   box-sizing: border-box;
 }
 
+.autocomplete-section {
+  display: flex;
+  flex-direction: row;
+}
 .autocompleteItem {
   width: 100%;
   padding: 5px;

--- a/assets/src/app.css
+++ b/assets/src/app.css
@@ -5,6 +5,7 @@
 html, body {
   margin: 0;
 }
+a { color: inherit; } 
 
 /* START:Atoms... maybe move to palette? */
 
@@ -92,16 +93,15 @@ input[type=text] {
   box-sizing: border-box;
 }
 
-.partnerItem {
+.autocompleteItem {
   width: 100%;
   padding: 5px;
   font-size: 14;
 }
 
-.partnerItem:hover {
+.autocompleteItem:hover {
   font-weight: bold;
   cursor: pointer;
-  border: 1px solid #444444
 }
 
 .autocomplete{

--- a/assets/src/app.css
+++ b/assets/src/app.css
@@ -81,3 +81,31 @@ section.artworks {
   height: 300px;
   padding: 10px;
 }
+
+input[type=text] {
+  width: 100%;
+  padding: 12px 20px;
+  margin: 8px 0;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.partnerItem {
+  width: 100%;
+  padding: 5px;
+  font-size: 14;
+}
+
+.partnerItem:hover {
+  font-weight: bold;
+  cursor: pointer;
+  border: 1px solid #444444
+}
+
+.autocomplete{
+  width: 90%;
+  margin: 20px;
+}
+

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,12 @@
 use Mix.Config
 
 config :apr,
-  ecto_repos: [Apr.Repo]
+  ecto_repos: [Apr.Repo],
+  gravity_api: Gravity
+
+config :apr, Gravity,
+  api_url: System.get_env("GRAVITY_API_URL") || "https://stagingapi.artsy.net",
+  api_token: System.get_env("GRAVITY_API_TOKEN")
 
 # Configures the endpoint
 config :apr, AprWeb.Endpoint,

--- a/lib/apr/gravity.ex
+++ b/lib/apr/gravity.ex
@@ -1,0 +1,18 @@
+defmodule Gravity do
+  use HTTPoison.Base
+
+  def process_request_headers(headers),
+    do:
+      Keyword.merge(headers, [
+        {:"X-XAPP-TOKEN", Application.get_env(:apr, Gravity)[:api_token]}
+      ])
+
+  def process_response_body(body) do
+    body
+    |> Jason.decode!()
+  end
+
+  def process_request_url(url) do
+    Application.get_env(:apr, Gravity)[:api_url] <> url
+  end
+end

--- a/lib/apr/gravity.ex
+++ b/lib/apr/gravity.ex
@@ -15,4 +15,14 @@ defmodule Gravity do
   def process_request_url(url) do
     Application.get_env(:apr, Gravity)[:api_url] <> url
   end
+
+  def match_partners(term, token) do
+    get!("/api/v1/match/partners", [{:"X-ACCESS-TOKEN", token}], params: %{term: term}).body
+    |> Enum.map(fn partner -> Map.take(partner, ["_id", "name"]) end)
+  end
+
+  def match_users(term, token) do
+    get!("/api/v1/match/users", [{:"X-ACCESS-TOKEN", token}], params: %{term: term}).body
+    |> Enum.map(fn partner -> Map.take(partner, ["_id", "name", "email"]) end)
+  end
 end

--- a/lib/apr_web/helpers/view_helper.ex
+++ b/lib/apr_web/helpers/view_helper.ex
@@ -1,11 +1,21 @@
 defmodule Apr.ViewHelper do
+  @exchange_url Application.get_env(:apr, :exchange)[:url]
+
   def exchange_link(order_id) do
-    Application.get_env(:apr, :exchange)[:url] <> "/admin/orders/#{order_id}"
+    "#{@exchange_url}/admin/orders/#{order_id}"
   end
 
   def currency(amount, currency \\ :USD) do
     amount
     |> Money.new(currency)
     |> Money.to_string()
+  end
+
+  def exchange_user_orders_link(user_id) do
+    "#{@exchange_url}/admin/orders?q%5Bbuyer_id_eq=#{user_id}"
+  end
+
+  def exchange_partner_orders_link(partner_id) do
+    "#{@exchange_url}/admin/orders?q%5Bseller_id_eq=#{partner_id}"
   end
 end

--- a/lib/apr_web/helpers/view_helper.ex
+++ b/lib/apr_web/helpers/view_helper.ex
@@ -1,21 +1,27 @@
 defmodule Apr.ViewHelper do
   @exchange_url Application.get_env(:apr, :exchange)[:url]
 
+  @spec exchange_link(String.t()) :: String.t()
   def exchange_link(order_id) do
     "#{@exchange_url}/admin/orders/#{order_id}"
   end
 
+  @spec currency(integer, atom | binary) :: String.t()
   def currency(amount, currency \\ :USD) do
     amount
     |> Money.new(currency)
     |> Money.to_string()
   end
 
+  @spec exchange_user_orders_link(String.t()) :: String.t()
   def exchange_user_orders_link(user_id) do
-    "#{@exchange_url}/admin/orders?q%5Bbuyer_id_eq=#{user_id}"
+    "#{@exchange_url}/admin/orders?q[buyer_id_eq]=#{user_id}"
+    |> URI.encode
   end
 
+  @spec exchange_partner_orders_link(String.t()) :: String.t()
   def exchange_partner_orders_link(partner_id) do
-    "#{@exchange_url}/admin/orders?q%5Bseller_id_eq=#{partner_id}"
+    "#{@exchange_url}/admin/orders?q[seller_id_eq]=#{partner_id}"
+    |> URI.encode
   end
 end

--- a/lib/apr_web/live/order_by_partner.ex
+++ b/lib/apr_web/live/order_by_partner.ex
@@ -1,0 +1,51 @@
+defmodule AprWeb.OrderByPartner do
+  use Phoenix.LiveView
+  @gravity_api Application.get_env(:apr, :gravity_api)
+
+  def render(assigns) do
+    ~L"""
+    <form phx-change="suggest" phx-submit="select" class="autocomplete" autocomplete="off">
+      <label for="q"> Find orders by Partner Name </label>
+      <input type="text" name="q" value="<%= @query %>" list="matches"
+            placeholder="Search for partners..."
+            <%= if @loading, do: "readonly" %> />
+      <%= for match <- @matches do %>
+        <div phx-click="select<%= match["_id"] %>" class="partnerItem"> <%= match["name"] %> </div>
+      <% end %>
+      <%= if @result do %><pre><%= @result %></pre><% end %>
+    </form>
+    """
+  end
+
+  def mount(session, socket) do
+    {:ok,
+     assign(socket,
+       query: nil,
+       result: nil,
+       loading: false,
+       matches: [],
+       access_token: session.access_token
+     )}
+  end
+
+  def handle_event("suggest", %{"q" => q}, socket) when byte_size(q) >= 3 do
+    matches = fetch_partners(q, socket.assigns.access_token)
+    {:noreply, assign(socket, matches: matches)}
+  end
+
+  def handle_event("suggest", _, socket), do: {:noreply, assign(socket, matches: [])}
+
+  def handle_event("select" <> partner_id, _, socket) do
+    {:stop,
+     socket
+     |> put_flash(:info, "Partner Selected")
+     |> redirect(
+       to: "https://exchange-staging.artsy.net/admin/orders?5Bseller_id_eq=#{partner_id}"
+     )}
+  end
+
+  defp fetch_partners(term, token) do
+    @gravity_api.get!("/api/v1/match/partners", [{:"X-ACCESS-TOKEN", token}], params: %{term: term}).body
+    |> Enum.map(fn partner -> Map.take(partner, ["_id", "name"]) end)
+  end
+end

--- a/lib/apr_web/live/order_by_partner.ex
+++ b/lib/apr_web/live/order_by_partner.ex
@@ -2,33 +2,34 @@ defmodule AprWeb.OrderByPartner do
   use Phoenix.LiveView
   import Apr.ViewHelper
   @gravity_api Application.get_env(:apr, :gravity_api)
-  @exchange_url Application.get_env(:apr, :exchange)[:url]
 
   def render(assigns) do
     ~L"""
-    <form phx-change="suggest_partner" class="autocomplete" autocomplete="off">
-      <label for="term"> Find orders by Partner </label>
-      <input type="text" name="term" value="<%= @partner_query %>" list="partner_matches"
-            placeholder="Search for partners..."
-            <%= if @loading, do: "readonly" %> />
-      <%= for match <- @partner_matches do %>
-        <div class="autocompleteItem">
-          <a href="<%= exchange_partner_orders_link(match["_id"]) %>" target="_blank"> <%= match["name"] %></a>
-        </div>
-      <% end %>
-    </form>
+    <div class="autocomplete-section">
+      <form phx-change="suggest_partner" class="autocomplete" autocomplete="off">
+        <label for="term"> Find orders by Partner </label>
+        <input type="text" name="term" value="<%= @partner_query %>" list="partner_matches"
+              placeholder="Search for partners..."
+              <%= if @loading, do: "readonly" %> />
+        <%= for match <- @partner_matches do %>
+          <div class="autocompleteItem">
+            <a href="<%= exchange_partner_orders_link(match["_id"]) %>" target="_blank"> <%= match["name"] %></a>
+          </div>
+        <% end %>
+      </form>
 
-    <form phx-change="suggest_user" class="autocomplete" autocomplete="off">
-      <label for="term"> Find orders by User </label>
-      <input type="text" name="term" value="<%= @partner_query %>" list="user_matches"
-            placeholder="Search for user..."
-            <%= if @loading, do: "readonly" %> />
-      <%= for match <- @user_matches do %>
-        <div class="autocompleteItem">
-          <a href="<%= exchange_user_orders_link(match["_id"]) %>" target="_blank"> <%= match["name"] %> - <%= match["email"] %></a>
-        </div>
-      <% end %>
-    </form>
+      <form phx-change="suggest_user" class="autocomplete" autocomplete="off">
+        <label for="term"> Find orders by User </label>
+        <input type="text" name="term" value="<%= @partner_query %>" list="user_matches"
+              placeholder="Search for user..."
+              <%= if @loading, do: "readonly" %> />
+        <%= for match <- @user_matches do %>
+          <div class="autocompleteItem">
+            <a href="<%= exchange_user_orders_link(match["_id"]) %>" target="_blank"> <%= match["name"] %> - <%= match["email"] %></a>
+          </div>
+        <% end %>
+      </form>
+    </div>
     """
   end
 
@@ -45,35 +46,16 @@ defmodule AprWeb.OrderByPartner do
   end
 
   def handle_event("suggest_partner", %{"term" => term}, socket) when byte_size(term) >= 3 do
-    partner_matches = fetch_partners(term, socket.assigns.access_token)
+    partner_matches = @gravity_api.match_partners(term, socket.assigns.access_token)
     {:noreply, assign(socket, partner_matches: partner_matches)}
   end
 
   def handle_event("suggest_partner", _, socket), do: {:noreply, assign(socket, partner_matches: [])}
 
   def handle_event("suggest_user", %{"term" => term}, socket) when byte_size(term) >= 3 do
-    user_matches = fetch_users(term, socket.assigns.access_token)
+    user_matches = @gravity_api.match_users(term, socket.assigns.access_token)
     {:noreply, assign(socket, user_matches: user_matches)}
   end
 
   def handle_event("suggest_user", _, socket), do: {:noreply, assign(socket, user_matches: [])}
-
-  def handle_event("select_partner" <> partner_id, _, socket) do
-    {:stop,
-     socket
-     |> put_flash(:info, "Partner Selected")
-     |> redirect(
-       to: "#{@exchange_url}/admin/orders?q%5Bseller_id_eq=#{partner_id}"
-     )}
-  end
-
-  defp fetch_partners(term, token) do
-    @gravity_api.get!("/api/v1/match/partners", [{:"X-ACCESS-TOKEN", token}], params: %{term: term}).body
-    |> Enum.map(fn partner -> Map.take(partner, ["_id", "name"]) end)
-  end
-
-  defp fetch_users(term, token) do
-    @gravity_api.get!("/api/v1/match/users", [{:"X-ACCESS-TOKEN", token}], params: %{term: term}).body
-    |> Enum.map(fn partner -> Map.take(partner, ["_id", "name", "email"]) end)
-  end
 end

--- a/lib/apr_web/live/order_by_partner.ex
+++ b/lib/apr_web/live/order_by_partner.ex
@@ -1,18 +1,33 @@
 defmodule AprWeb.OrderByPartner do
   use Phoenix.LiveView
+  import Apr.ViewHelper
   @gravity_api Application.get_env(:apr, :gravity_api)
+  @exchange_url Application.get_env(:apr, :exchange)[:url]
 
   def render(assigns) do
     ~L"""
-    <form phx-change="suggest" phx-submit="select" class="autocomplete" autocomplete="off">
-      <label for="q"> Find orders by Partner Name </label>
-      <input type="text" name="q" value="<%= @query %>" list="matches"
+    <form phx-change="suggest_partner" class="autocomplete" autocomplete="off">
+      <label for="term"> Find orders by Partner </label>
+      <input type="text" name="term" value="<%= @partner_query %>" list="partner_matches"
             placeholder="Search for partners..."
             <%= if @loading, do: "readonly" %> />
-      <%= for match <- @matches do %>
-        <div phx-click="select<%= match["_id"] %>" class="partnerItem"> <%= match["name"] %> </div>
+      <%= for match <- @partner_matches do %>
+        <div class="autocompleteItem">
+          <a href="<%= exchange_partner_orders_link(match["_id"]) %>" target="_blank"> <%= match["name"] %></a>
+        </div>
       <% end %>
-      <%= if @result do %><pre><%= @result %></pre><% end %>
+    </form>
+
+    <form phx-change="suggest_user" class="autocomplete" autocomplete="off">
+      <label for="term"> Find orders by User </label>
+      <input type="text" name="term" value="<%= @partner_query %>" list="user_matches"
+            placeholder="Search for user..."
+            <%= if @loading, do: "readonly" %> />
+      <%= for match <- @user_matches do %>
+        <div class="autocompleteItem">
+          <a href="<%= exchange_user_orders_link(match["_id"]) %>" target="_blank"> <%= match["name"] %> - <%= match["email"] %></a>
+        </div>
+      <% end %>
     </form>
     """
   end
@@ -20,32 +35,45 @@ defmodule AprWeb.OrderByPartner do
   def mount(session, socket) do
     {:ok,
      assign(socket,
-       query: nil,
-       result: nil,
+       partner_query: nil,
+       user_query: nil,
        loading: false,
-       matches: [],
+       partner_matches: [],
+       user_matches: [],
        access_token: session.access_token
      )}
   end
 
-  def handle_event("suggest", %{"q" => q}, socket) when byte_size(q) >= 3 do
-    matches = fetch_partners(q, socket.assigns.access_token)
-    {:noreply, assign(socket, matches: matches)}
+  def handle_event("suggest_partner", %{"term" => term}, socket) when byte_size(term) >= 3 do
+    partner_matches = fetch_partners(term, socket.assigns.access_token)
+    {:noreply, assign(socket, partner_matches: partner_matches)}
   end
 
-  def handle_event("suggest", _, socket), do: {:noreply, assign(socket, matches: [])}
+  def handle_event("suggest_partner", _, socket), do: {:noreply, assign(socket, partner_matches: [])}
 
-  def handle_event("select" <> partner_id, _, socket) do
+  def handle_event("suggest_user", %{"term" => term}, socket) when byte_size(term) >= 3 do
+    user_matches = fetch_users(term, socket.assigns.access_token)
+    {:noreply, assign(socket, user_matches: user_matches)}
+  end
+
+  def handle_event("suggest_user", _, socket), do: {:noreply, assign(socket, user_matches: [])}
+
+  def handle_event("select_partner" <> partner_id, _, socket) do
     {:stop,
      socket
      |> put_flash(:info, "Partner Selected")
      |> redirect(
-       to: "https://exchange-staging.artsy.net/admin/orders?5Bseller_id_eq=#{partner_id}"
+       to: "#{@exchange_url}/admin/orders?q%5Bseller_id_eq=#{partner_id}"
      )}
   end
 
   defp fetch_partners(term, token) do
     @gravity_api.get!("/api/v1/match/partners", [{:"X-ACCESS-TOKEN", token}], params: %{term: term}).body
     |> Enum.map(fn partner -> Map.take(partner, ["_id", "name"]) end)
+  end
+
+  defp fetch_users(term, token) do
+    @gravity_api.get!("/api/v1/match/users", [{:"X-ACCESS-TOKEN", token}], params: %{term: term}).body
+    |> Enum.map(fn partner -> Map.take(partner, ["_id", "name", "email"]) end)
   end
 end

--- a/lib/apr_web/router.ex
+++ b/lib/apr_web/router.ex
@@ -27,5 +27,6 @@ defmodule AprWeb.Router do
 
     get "/", PageController, :dashboard
     get "/dashboard", PageController, :dashboard
+    live "/partner_selection", OrderByPartner, session: [:access_token]
   end
 end


### PR DESCRIPTION
# Problem
Exchange does not store partner and user names, but CRT wants to be able to search orders by these two options. 
 
https://artsyproduct.atlassian.net/browse/PURCHASE-1149 and https://artsyproduct.atlassian.net/browse/PURCHASE-1215

# Possible Choices

## Add search by names to Exchange's existing admin
Exchange admin uses [ActiveAdmin](https://github.com/activeadmin/activeadmin) for it's admin section.
This is pretty unknown to me at the moment on how it's doable via `ActiveAdmin`.  The known option would be to follow patterns in elsewhere where we create normal rails controller and then do search in rails controller and handle the results on the front end. This would work but would have need few boilerplates to get it working.

## Go Fun/Experimental Direction, Use Phoenix LiveView in APRd
Its Friday and I had a week full of MP AST stuff. So I tried to quickly setup a liveview for partner search autocomplete, this thing came together lot faster than what i thought so ended up also adding search by username in there since that was only 2 more lines of code to do. 
We basically show the autocomplete results and clicking on any of the resuts would open a new tab, taking user to Exchange admin filtered by partner or user.
This generally is strange to have filtering in a different app but:
- APRd's original purpose was a dashboard for CRT, this seems to nicely fit that criteria
- APRd is already Artsy authenticated and limited to `sales_admin` role so we are 👍 there as well.

I demo'd this to CRT and seems to work for them pretty nicely. So im rooting for this approach. A 3+2 set of stories ended up being 20min phoenix exploration.



![Jun-28-2019 13-59-29](https://user-images.githubusercontent.com/1230819/60361758-10b1f200-99ad-11e9-9a5b-ffd0e938ac37.gif)


# Migration
We need to set few new Environment variables:
```
GRAVITY_API_TOKEN=<xapp token for this app>
GRAVITY_API_URL=https://stagingapi.artsy.net
```