### PR TITLE
Use circle orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,53 +1,48 @@
-version: 2
-jobs:
-  test:
-    docker:
-      - image: artsy/hokusai:0.5.4
-    steps:
-      - add_ssh_keys
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Test
-          command: hokusai test
-  push:
-    docker:
-      - image: artsy/hokusai:0.5.4
-    steps:
-      - add_ssh_keys
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Push
-          command: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
-  deploy:
-    docker:
-      - image: artsy/hokusai:0.5.4
-    steps:
-      - add_ssh_keys
-      - checkout
-      - run:
-          name: Configure
-          command: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
-      - run:
-          name: Deploy
-          command: hokusai staging deploy $CIRCLE_SHA1
+version: 2.1
+
+orbs:
+  hokusai: artsy/hokusai@0.7.0
+
+not_staging_or_release: &not_staging_or_release
+  filters:
+    branches:
+      ignore:
+        - staging
+        - release
+
+only_master: &only_master
+  context: hokusai
+  filters:
+    branches:
+      only: master
+
+only_release: &only_release
+  context: hokusai
+  filters:
+    branches:
+      only: release
+
 workflows:
-  version: 2
-  default:
+  build-deploy:
     jobs:
-      - test
-      - push:
-          context: hokusai
-          filters:
-            branches:
-              only: master
+      # pre-staging
+      - hokusai/test:
+          name: test
+          <<: *not_staging_or_release
+
+      # staging
+      - hokusai/push:
+          name: push-staging-image
+          <<: *only_master
           requires:
             - test
-      - deploy:
-          context: hokusai
-          filters:
-            branches:
-              only: master
+
+      - hokusai/deploy-staging:
+          <<: *only_master
+          project-name: apr-dashboard
           requires:
-            - push
+            - push-staging-image
+
+      # release
+      - hokusai/deploy-production:
+          <<: *only_release

--- a/README.md
+++ b/README.md
@@ -1,52 +1,40 @@
 # APRd (Artsy Real-time Dashboard) [![CircleCI](https://circleci.com/gh/artsy/apr-dashboard/tree/master.svg?style=svg)](https://circleci.com/gh/artsy/apr-dashboard/tree/master)
+
 APRd (aka. APR dashboard), is a real-time dashboard built in [Elixir](https://elixir-lang.org/) on [Phoenix Framework](https://phoenixframework.org/). For it's real-time dashboard it's using [Phoenix Live View](https://github.com/phoenixframework/phoenix_live_view) to be able to provide websocket based pages that can update in real-time based on updates on the server side.
 
 ## Meta
 
-* State: production
-* Production: https://aprd.artsy.net/dashboard
-* Staging: https://aprd-staging.artsy.net/dashboard
-* GitHub: https://github.com/artsy/apr-dashboard/
-* Point People: [@ashkan18][ashkan18], [@zephraph][zephraph]
-
-
-## Deployment
-### Staging
-PRs merged to `master` are automatically deployed to staging by CI.
-
-### Production
-Mention in #dev slack channel that you are going to deploy and then run:
-```
-hokusai pipeline promote --git-remote upstream
-```
-Assuming `upstream` points to Artsy's repository.
-
+- State: production
+- Production: https://aprd.artsy.net/dashboard
+- Staging: https://aprd-staging.artsy.net/dashboard
+- GitHub: https://github.com/artsy/apr-dashboard/
+- CI: [CircleCI](https://circleci.com/gh/artsy/apr-dashboard); merged PRs to artsy/apr-dashboard#master are automatically deployed to staging. PRs from `staging` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/apr-dashboard/compare/release...staging?expand=1)
+- Point People: [@ashkan18][ashkan18], [@zephraph][zephraph]
 
 ## Setup
 
-* Fork the project to your GitHub account
+- Fork the project to your GitHub account
 
-* Clone your fork:
+- Clone your fork:
   ```
   $ git clone git@github.com:your-github-username/apr-dashboard.git
   ```
-* Install dependencies with `mix deps.get`
-* Create and migrate your database with `mix ecto.setup`
-* Install Node.js dependencies with `cd assets && npm install`
-* Copy `.env.example` to `.env`
-* We use [Phoenix Live View](https://github.com/phoenixframework/phoenix_live_view) for our real-time data presentation. Make sure to set `SECRET_SALT` in your `.env`. Generate a secret salt with:
-  * `mix phx.gen.secret 32`
-* Make set your RabbitMQ setting in `.env`
-* Start Phoenix endpoint with `mix phx.server`
+- Install dependencies with `mix deps.get`
+- Create and migrate your database with `mix ecto.setup`
+- Install Node.js dependencies with `cd assets && npm install`
+- Copy `.env.example` to `.env`
+- We use [Phoenix Live View](https://github.com/phoenixframework/phoenix_live_view) for our real-time data presentation. Make sure to set `SECRET_SALT` in your `.env`. Generate a secret salt with:
+  - `mix phx.gen.secret 32`
+- Make set your RabbitMQ setting in `.env`
+- Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000/dashboard`](http://localhost:4000/dashboard) from your browser.
 
-
 ## Architecture
+
 APRd listens on RabbitMQ for different topics. Once it receives a new event, it will store a copy of that event locally in it's database so we can later process the data and provide detailed and aggregated data.
 
 Whenever we receive a new event, after storing the event locally, we use Phoenix's local PUB/SUB to broadcast we received an event. And then our websocket live views are listening on this internal PUB/SUB and they update the data on listening Webosckets reflecting the latest event updated.
-
 
 [ashkan18]: https://github.com/ashkan18
 [zephraph]: https://github.com/zephraph

--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -1,0 +1,8 @@
+---
+version: '2'
+services:
+  aprd:
+    build:
+      context: ../
+      args:
+        SECRET_KEY_BASE: ${SECRET_KEY_BASE}

--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -1,8 +1,0 @@
----
-version: '2'
-services:
-  aprd:
-    build:
-      context: ../
-      args:
-        SECRET_KEY_BASE: ${SECRET_KEY_BASE}

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,3 +1,5 @@
 ---
 project-name: aprd
-pre-deploy: 'mix ecto.migrate'
+pre-deploy: "mix ecto.migrate"
+git-remote: git@github.com:artsy/apr-dashboard.git
+hokusai-required-version: "~=0.5"

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: "2"
 services:
   aprd:
     extends:


### PR DESCRIPTION
Updates circle config to use orbs for all steps, and implements PR-based release process. A r/w key has been added to github and circle. 

Readme changes are disguised by prettier, but adds current info on deployment.